### PR TITLE
Adjustments to zoom

### DIFF
--- a/src/addons/group.js
+++ b/src/addons/group.js
@@ -42,7 +42,7 @@ const group = (G) => {
     // 2) Add new gruop node
     parentData.nodes.push(groupNode);
 
-    G.render();
+    await G.render();
   };
 
   /**
@@ -65,7 +65,7 @@ const group = (G) => {
     });
     delete groupData.nodes;
 
-    G.render();
+    await G.render();
   };
 
   return [

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -544,7 +544,7 @@ export default class SVGRenderer {
       this.zoom.transform,
       d3.zoomIdentity.translate(0, 0).scale(zoomLevel).translate(
         (-(this.layout.width * zoomLevel * 0.5) + 0.5 * this.chartSize.width) / zoomLevel,
-        0
+        (-(this.layout.height * zoomLevel * 0.5) + 0.5 * this.chartSize.height) / zoomLevel
       )
     );
   }

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -534,9 +534,10 @@ export default class SVGRenderer {
         .attr('fill-opacity', 0.1);
     }
 
+    const minZoom = 0.05;
     const maxZoom = Math.max(2, Math.floor(this.layout.width / this.chartSize.width));
-    const zoomLevel = 1 / (this.layout.height / this.chartSize.height);
-    this.zoom = d3.zoom().scaleExtent([zoomLevel, maxZoom]).on('zoom', zoomed).on('end', zoomEnd);
+    const zoomLevel = Math.min(1, 1 / (this.layout.height / this.chartSize.height));
+    this.zoom = d3.zoom().scaleExtent([minZoom, maxZoom]).on('zoom', zoomed).on('end', zoomEnd);
     svg.call(this.zoom).on('dblclick.zoom', null);
 
     svg.call(


### PR DESCRIPTION
This change stops the default behaviour of zooming really close to small graphs, centres the graph vertically and grouping nodes now correctly awaits render.