### PR TITLE
Group shouldnt render and nodes shouldnt tween

### DIFF
--- a/src/addons/group.js
+++ b/src/addons/group.js
@@ -7,7 +7,7 @@ const group = (G) => {
    * @param {string} groupName
    * @param {array} nodeIds - node identifiers
    */
-  const group = async(groupName, nodeIds) => {
+  const group = (groupName, nodeIds) => {
     const chart = G.chart;
 
     // 0) check parent
@@ -41,15 +41,13 @@ const group = (G) => {
 
     // 2) Add new gruop node
     parentData.nodes.push(groupNode);
-
-    await G.render();
   };
 
   /**
    * Ungroup
    * @param {string} groupName
    */
-  const ungroup = async (groupName) => {
+  const ungroup = (groupName) => {
     const chart = G.chart;
     const groupData = chart.selectAll('.node').filter(d => d.id === groupName).data()[0];
     const parentData = groupData.parent;
@@ -64,8 +62,6 @@ const group = (G) => {
       parentData.nodes.push(temp);
     });
     delete groupData.nodes;
-
-    await G.render();
   };
 
   return [

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -327,9 +327,7 @@ export default class SVGRenderer {
           _recursiveBuild(selection.select('.node-children'), d.nodes);
         });
 
-        g.transition().duration(1000).attr('transform', d => {
-          return svgUtil.translate(d.x, d.y);
-        });
+        g.attr('transform', d => svgUtil.translate(d.x, d.y));
       });
     };
     _recursiveBuild(chart, this.layout.nodes);


### PR DESCRIPTION
some small changes - calling group() no longer calls render() which is nice when you're grouping multiple groups - does mean that you need to call render() yourself after grouping though.  Also, node positions were being transitioned, which wasn't ideal.