### PR TITLE
Enable edge controls in the example

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -196,7 +196,7 @@ const renderer = new TestRenderer({
   el: document.getElementById('test'),
   adapter: new DagreAdapter({ nodeWidth: 100, nodeHeight: 50 }),
   renderMode: 'basic',
-  useEdgeControl: false,
+  useEdgeControl: true,
   useMinimap: true,
   addons: [ group, nodeSize, highlight, nodeDrag, expandCollapse, panZoom ]
 });

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -197,6 +197,14 @@ export default class SVGRenderer {
       .attr('fill', 'transparent');
   }
 
+  renderEdgeControl(edgeSelection) {
+    edgeSelection.append('circle')
+      .attr('cx', 0)
+      .attr('cy', 0)
+      .attr('r', 10)
+      .attr('fill', '#f80');
+  }
+
   // FIXME: Should provide very basic marker definitions and leave the work to the
   // implementation renderers
   buildDefs() {


### PR DESCRIPTION
This came up while trying to enable the controls in the example. 
- Set the `useEdgeControl` flag to true to showcase this feature as well in the example. My rationale is that the miniMap is also visible in the example so we might as well enable controls.
- Added a basic rendering of edge controls in the SVGRenderer so if someone enables the flag to true they are visible immediately without having to write a method for it. I feel we might also want to add some basic rendering of nodes and edges as well so if someone doesn't write a renderer, she can use the default one. 

NOTE: I changed mind and kept the name of `renderEdgeControls`. I realized you use similar names for the rest of methods so I just want to be consistent. 