### PR TITLE
Fix node.parent bug, add api-pan

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -112,7 +112,6 @@ class DagreAdapter {
       if (n.nodes) {
         for (let i = 0; i < n.nodes.length; i++) {
           g.setParent(n.nodes[i].id, n.id);
-          console.log(n.nodes[i].id, n.id);
         }
       }
     });

--- a/src/addons/panZoom.js
+++ b/src/addons/panZoom.js
@@ -38,12 +38,14 @@ const panZoom = (G) => {
     const node = chart.selectAll('.node').filter(d => d.id === nodeId);
     if (_.isNil(node)) return;
 
+    const parentMap = G.parentMap;
+
     let temp = node.datum();
     let globalX = temp.x;
     let globalY = temp.y;
 
-    while (_.isNil(temp.parent)) {
-      temp = temp.parent;
+    while (parentMap.has(temp.id) === true) {
+      temp = parentMap.get(temp.id);
       globalX += temp.x;
       globalY += temp.y;
     }
@@ -59,9 +61,20 @@ const panZoom = (G) => {
     );
   };
 
+  const pan = (x, y, duration) => {
+    const chart = G.chart;
+    const t = d3.zoomTransform(chart.node());
+    const svg = d3.select(G.svgEl);
+    svg.transition().duration(duration).call(
+      G.zoom.transform,
+      d3.zoomIdentity.translate(t.x, t.y).scale(t.k).translate(x, y)
+    );
+  };
+
   return [
     { name: 'centerGraph', fn: centerGraph },
-    { name: 'moveTo', fn: moveTo }
+    { name: 'moveTo', fn: moveTo },
+    { name: 'panGraph', fn: pan }
   ];
 };
 


### PR DESCRIPTION
### Summary
- Forgot to fix panZoom addon when we removed reliance on node.parent.
- Added a panGraph for programmable navigation

### Testing
- In the example, you can do `renderer.panGraph(X, Y, Duration)` in the console
- In the example, you can do `renderer.moveTo(NodeID, Duration)` in the console