### PR TITLE
Stable layout option

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -8,9 +8,17 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dagre/0.8.5/dagre.min.js" integrity="sha512-psLUZfcgPmi012lcpVHkWoOqyztollwCGu4w/mXijFMK/YcdUdP06voJNVOJ7f/dUIlO2tGlDLuypRyXX2lcvQ==" crossorigin="anonymous"></script>
 <script src="./svg-flowgraph.min.js"></script>
 <title>Demo Graph</title>
+<style>
+body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+</style>
 </head>
 <body>
-  <div id="test" style="margin: 10px; width:50%; height: 450px; border: 1px solid #888; background: #FCFCFC" />
+  <div id="test" style="width:600px; height: 450px; border: 1px solid #888; background: #FCFCFC" />
 </body>
 <script>
 
@@ -18,6 +26,16 @@ const pathFn = d3.line() .x(d => d.x) .y(d => d.y);
 
 
 class TestRenderer extends myLibrary.SVGRenderer {
+  async render() {
+    await super.render();
+    d3.select(this.svgEl).select('.background-layer').selectAll('*').remove();
+    d3.select(this.svgEl).select('.background-layer')
+      .append('text')
+      .attr('y', 15)
+      .attr('x', this.chartSize.width - 10)
+      .attr('text-anchor', 'end')
+      .text('stable layout ' + this.options.useStableLayout);
+  }
 
   renderEdgeControl(selection) {
     selection.append('circle')
@@ -27,7 +45,7 @@ class TestRenderer extends myLibrary.SVGRenderer {
       .attr('fill', '#f80');
   }
 
-  renderNode(nodeSelection) {
+  renderNodeAdded(nodeSelection) {
     nodeSelection.each(function() {
       const selection = d3.select(this);
 
@@ -57,8 +75,13 @@ class TestRenderer extends myLibrary.SVGRenderer {
       .style('text-anchor', d => d.nodes ? 'left' : 'middle')
       .text(d => d.data.label);
   }
+  renderNodeUpdated(nodeSelection) {
+  }
+  renderNodeRemoved(nodeSelection) {
+    nodeSelection.remove();
+  }
 
-  renderEdge(edgeSelection) {
+  renderEdgeAdded(edgeSelection) {
     edgeSelection.append('path')
       .attr('d', d => pathFn(d.points))
       .style('fill', 'none')
@@ -74,6 +97,13 @@ class TestRenderer extends myLibrary.SVGRenderer {
         return `url(#start-${source}-${target})`;
       });
   }
+  renderEdgeUpdated(edgeSelection) {
+    edgeSelection.select('path').attr('d', d => pathFn(d.points));
+  }
+  renderEdgeRemoved(edgeSelection) {
+    edgeSelection.remove();
+  }
+
 }
 
 // An example Adapter using Dagre (Not compounded)
@@ -166,11 +196,7 @@ const graph = {
         { id: 'Sub 1', label: 'Sub 1' },
         { id: 'L2', label: 'L2',
           nodes: [
-            { id: 'L3', label: 'L3',
-              nodes: [
-                { id: 'L4', label: 'L4' }
-              ]
-            }
+            { id: 'L4', label: 'L4' }
           ]
         }
       ]
@@ -185,6 +211,30 @@ const graph = {
   ]
 };
 
+const graph2 = {
+  id: 'container',
+  nodes: [
+    { id: 'Node A', label: 'Node A' },
+    { id: 'Node B', label: 'Node B' },
+    { id: 'Node C', label: 'Node C' },
+    { id: 'L1', label: 'L1',
+      nodes: [
+        { id: 'L2', label: 'L2',
+          nodes: [
+            { id: 'L4', label: 'L4' }
+          ]
+        }
+      ]
+    }
+  ],
+  edges: [
+    { id: 'Edge 1', source: 'Node A', target: 'Node B' },
+    { id: 'Edge 3', source: 'L4', target: 'Node A' },
+    { id: 'Edge 4', source: 'L4', target: 'L4' },
+  ]
+};
+
+
 const group = myLibrary.group;
 const nodeSize = myLibrary.nodeSize;
 const nodeDrag = myLibrary.nodeDrag;
@@ -196,9 +246,10 @@ const traverse = myLibrary.traverse;
 const renderer = new TestRenderer({
   el: document.getElementById('test'),
   adapter: new DagreAdapter({ nodeWidth: 100, nodeHeight: 50 }),
-  renderMode: 'basic',
+  renderMode: 'delta',
   useEdgeControl: true,
   useMinimap: true,
+  useStableLayout: true,
   addons: [ group, nodeSize, highlight, nodeDrag, expandCollapse, panZoom ]
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-flowgraph",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "SVG-based renderering utilities for interacting with graphs",
   "main": "dist/cjs/main.js",
   "module": "dist/esm/main.js",

--- a/src/addons/node-drag.js
+++ b/src/addons/node-drag.js
@@ -13,9 +13,10 @@ const nodeDrag = (G) => {
    */
   const enableDrag = (useAStarRouting) => {
     const chart = G.chart;
-    const data = flatten(G.layout);
+    let data = null;
 
     function dragStart(evt) {
+      data = flatten(G.layout);
       evt.sourceEvent.stopPropagation();
     }
 
@@ -100,6 +101,20 @@ const nodeDrag = (G) => {
         G.updateEdgePoints();
       }
       edgeTracker.clear();
+
+      data.nodes.forEach(node => {
+        G.oldNodeMap.set(node.id, {
+          x: node.x,
+          y: node.y,
+          width: node.width,
+          height: node.height
+        });
+      });
+      data.edges.forEach(edge => {
+        G.oldEdgeMap.set(edge.id, {
+          points: edge.points
+        });
+      });
     }
 
     // FIXME: Need to disable current listeners first before assigning new ones?

--- a/src/addons/node-drag.js
+++ b/src/addons/node-drag.js
@@ -2,8 +2,6 @@ import * as d3 from 'd3';
 import { flatten } from '../utils';
 import { translate } from '../utils/svg-util';
 import { getAStarPath } from '../utils/a-star';
-// import { simplifyPath } from '../utils/simplify';
-
 
 const nodeDrag = (G) => {
   const edgeTracker = new Map();
@@ -101,20 +99,6 @@ const nodeDrag = (G) => {
         G.updateEdgePoints();
       }
       edgeTracker.clear();
-
-      data.nodes.forEach(node => {
-        G.oldNodeMap.set(node.id, {
-          x: node.x,
-          y: node.y,
-          width: node.width,
-          height: node.height
-        });
-      });
-      data.edges.forEach(edge => {
-        G.oldEdgeMap.set(edge.id, {
-          points: edge.points
-        });
-      });
     }
 
     // FIXME: Need to disable current listeners first before assigning new ones?

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -156,6 +156,26 @@ export default class SVGRenderer {
    */
   async render() {
     const options = this.options;
+
+    // Cache previous layout, if any
+    this.oldNodeMap.clear();
+    this.oldEdgeMap.clear();
+    if (this.chart) {
+      this.chart.selectAll('.node').each(d => {
+        this.oldNodeMap.set(d.id, {
+          x: d.x,
+          y: d.y,
+          width: d.width,
+          height: d.height
+        });
+      });
+      this.chart.selectAll('.edge').each(d => {
+        this.oldEdgeMap.set(d.id, {
+          points: d.points
+        });
+      });
+    }
+
     if (!this.layout) {
       throw new Error('Layout data not set');
     }
@@ -185,23 +205,6 @@ export default class SVGRenderer {
     if (options.useMinimap === true) {
       this.renderMinimap();
     }
-
-    this.oldNodeMap.clear();
-    traverse(this.layout, (node) => {
-      this.oldNodeMap.set(node.id, {
-        x: node.x,
-        y: node.y,
-        width: node.width,
-        height: node.height
-      });
-      if (node.edges) {
-        node.edges.forEach(edge => {
-          this.oldEdgeMap.set(edge.id, {
-            points: edge.points
-          });
-        });
-      }
-    });
   }
 
   renderMinimap() {

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -67,6 +67,8 @@ export default class SVGRenderer {
     this.options.edgeControlOffsetType = this.options.edgeControlOffsetType || 'percentage';
     this.options.edgeControlOffset = this.options.edgeControlOffset || 0.66;
     this.options.useMinimap = this.options.useMinimap || false;
+    this.options.useStableLayout = this.options.useStableLayout || false;
+
     this.options.addons = this.options.addons || [];
 
     // Primitive add-on system
@@ -160,7 +162,7 @@ export default class SVGRenderer {
     // Cache previous layout, if any
     this.oldNodeMap.clear();
     this.oldEdgeMap.clear();
-    if (this.chart) {
+    if (this.chart && options.useStableLayout === true) {
       this.chart.selectAll('.node').each(d => {
         this.oldNodeMap.set(d.id, {
           x: d.x,
@@ -285,6 +287,7 @@ export default class SVGRenderer {
   renderEdgesDelta() {
     const chart = this.chart;
     const oldEdgeMap = this.oldEdgeMap;
+    const useStableLayout = this.options.useStableLayout;
     let allEdges = [];
 
     traverse(this.layout, (node) => {
@@ -295,7 +298,7 @@ export default class SVGRenderer {
 
     // Test stablization
     allEdges.forEach(edge => {
-      if (oldEdgeMap.has(edge.id)) {
+      if (useStableLayout === true && oldEdgeMap.has(edge.id)) {
         edge.points = oldEdgeMap.get(edge.id).points;
       }
     });
@@ -348,6 +351,7 @@ export default class SVGRenderer {
   renderNodesDelta() {
     const chart = this.chart;
     const oldNodeMap = this.oldNodeMap;
+    const useStableLayout = this.options.useStableLayout;
 
     const _recursiveBuild = (selection, childrenNodes) => {
       if (!childrenNodes) return;
@@ -372,7 +376,7 @@ export default class SVGRenderer {
           if (selection.select('.node-ui').size() === 0) {
             selection.append('g').classed('node-ui', true);
           }
-          if (oldNodeMap.has(d.id)) {
+          if (useStableLayout === true && oldNodeMap.has(d.id)) {
             const oldPosition = oldNodeMap.get(d.id);
             d.x = oldPosition.x;
             d.y = oldPosition.y;

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -287,7 +287,7 @@ export default class SVGRenderer {
   renderEdgesDelta() {
     const chart = this.chart;
     const oldEdgeMap = this.oldEdgeMap;
-    const useStableLayout = this.options.useStableLayout;
+    const useStableLayout = this.options.useStableLayout && flatten(this.layout).edges.length < chart.selectAll('.edge').size();
     let allEdges = [];
 
     traverse(this.layout, (node) => {
@@ -351,7 +351,7 @@ export default class SVGRenderer {
   renderNodesDelta() {
     const chart = this.chart;
     const oldNodeMap = this.oldNodeMap;
-    const useStableLayout = this.options.useStableLayout;
+    const useStableLayout = this.options.useStableLayout && (flatten(this.layout).nodes.length - 1) < chart.selectAll('.node').size();
 
     const _recursiveBuild = (selection, childrenNodes) => {
       if (!childrenNodes) return;


### PR DESCRIPTION
### Summary
Added a very basic option to keep layout stable. Note this is not a full fledged solution as it doesn't check when nodes swap into different hierarchies.


### Test
#### With stable layout
- npm run dev
- open console
- Run renderer.setData(graph2)
- Run renderer.render()
The graph will change but the remaining nodes/edges will be stable, drag things around and it will function as normal


#### With stable layout
- npm run dev
- open console
- Run renderer.setData(graph2)
- Run renderer.render()
The graph will be re-rendered anew, existing nodes/edges may shift around

 