### PR TITLE
add option to preserve zoom and pan when graph is re-rendered

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-flowgraph",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "SVG-based renderering utilities for interacting with graphs",
   "main": "dist/cjs/main.js",
   "module": "dist/esm/main.js",


### PR DESCRIPTION
## summary
- adds an option in the options object to `useStableZoomPan` which preserves the current state of zoom and pan whenever render is called
## testing 
- open up the test project
- set `renderer.options.useStableZoomPan = true`
- zoom and pan around
- call `renderer.render()` and ensure zoom/pan is not reset
- test it with `renderer.options.useStableZoomPan = false` to ensure that it does still reset